### PR TITLE
Remove margin of headers

### DIFF
--- a/rxmarkdown/src/main/java/com/yydcdut/rxmarkdown/grammar/android/HeaderGrammar.java
+++ b/rxmarkdown/src/main/java/com/yydcdut/rxmarkdown/grammar/android/HeaderGrammar.java
@@ -122,7 +122,6 @@ class HeaderGrammar extends AbsAndroidGrammar {
             ssb.delete(0, KEY_0_HEADER.length());
             ssb.setSpan(new RelativeSizeSpan(mHeader1RelativeSize), 0, ssb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
-        marginSSBLeft(ssb, 10);
         return ssb;
     }
 


### PR DESCRIPTION
Headings should begin at the same horizontal position as normal text (enhances readability). Therefore, I propose to remove the extra margin for headings. See #8.